### PR TITLE
fix: preserve amount sign from source CSV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ The app is a FastAPI REST API that ingests bank CSV exports, normalizes them thr
 
 **"N/A" convention**: All `TransactionCreate` fields are required with no defaults. When a parser cannot populate a string field from CSV data, it substitutes `"N/A"` using the `BaseParser` helpers — the responsibility lives in the parser layer, not the Pydantic model.
 
-**Amounts are always positive**: `amount` is stored as an absolute value; the `type` field (`"debit"` or `"credit"`) conveys direction. The `@field_validator("amount")` enforces `> 0`.
+**Amount sign convention**: `amount` preserves the sign from the source CSV — negative for outflows (debits/purchases), positive for inflows (credits/payments). The `type` field (`"debit"` or `"credit"`) is set independently from the CSV's transaction type column. The `@field_validator("amount")` rejects zero but allows negative values.
 
 **Test isolation**: Tests use an in-memory SQLite engine (session-scoped) with a rollback-per-test pattern — each test gets a transaction that rolls back rather than a fresh DB, keeping tests fast. The `client` fixture overrides the `get_db` FastAPI dependency via `app.dependency_overrides`.
 
-**Chase CSV format**: `Transaction Date,Post Date,Description,Category,Type,Amount,Memo` — `Type` values `Sale`→`debit`, `Payment`/`Return`→`credit`. Date format `%m/%d/%Y`. Amounts may be negative in the CSV; `_safe_float` takes the absolute value.
+**Chase CSV format**: `Transaction Date,Post Date,Description,Category,Type,Amount,Memo` — `Type` values `Sale`→`debit`, `Payment`/`Return`→`credit`. Date format `%m/%d/%Y`. Amounts in the CSV are negative for purchases and positive for payments; `_safe_float` preserves the sign.

--- a/src/brokelog/models.py
+++ b/src/brokelog/models.py
@@ -46,8 +46,8 @@ class TransactionBase(BaseModel):
     @classmethod
     def validate_amount(cls, v: object) -> float:
         result = float(str(v))
-        if result <= 0:
-            raise ValueError("amount must be a positive number")
+        if result == 0:
+            raise ValueError("amount must be non-zero")
         return result
 
 

--- a/src/brokelog/parsers/base.py
+++ b/src/brokelog/parsers/base.py
@@ -17,7 +17,7 @@ class BaseParser:
             raise ValueError(f"Cannot convert null/NaN to float: {val!r}")
         # Replace unicode minus (U+2212) with ASCII minus, strip currency symbols
         cleaned = str(val).replace("\u2212", "-").replace("$", "").replace(",", "").strip()
-        return abs(float(cleaned))
+        return float(cleaned)
 
     def _safe_date(self, val: Any, fmt: str | None = None) -> date:
         if pd.isna(val):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -32,10 +32,14 @@ class TestChaseParser:
         assert len(credits) == 1
         assert credits[0].description == "PAYROLL"
 
-    def test_amounts_are_positive(self):
+    def test_amount_signs_match_type(self):
         parser = ChaseParser()
         result = parser.parse(_df(CHASE_CSV_CONTENT), account="Chase Checking", owner="alice")
-        assert all(t.amount > 0 for t in result)
+        for t in result:
+            if t.type == "debit":
+                assert t.amount < 0
+            else:
+                assert t.amount > 0
 
     def test_blank_category_becomes_na(self):
         parser = ChaseParser()


### PR DESCRIPTION
Remove abs() from _safe_float so negative amounts (purchases/debits) stay negative and positive amounts (payments/credits) stay positive. Update the Pydantic validator to reject zero instead of negative values, and update the test and CLAUDE.md to reflect the new sign convention.

Closes #2